### PR TITLE
chore: add Backstage catalog-info.yaml for service discovery

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: python-bandwidth-sdk
+  description: Python SDK for Bandwidth communications API
+  annotations:
+    github.com/project-slug: Spaced-Out/python-bandwidth-sdk
+    backstage.io/techdocs-ref: dir:.
+  tags:
+  - python
+  links:
+  - url: https://github.com/Spaced-Out/python-bandwidth-sdk
+    title: GitHub Repository
+    icon: github
+spec:
+  type: library
+  lifecycle: production
+  owner: group:default/sense-engineering
+  system: system:default/other


### PR DESCRIPTION
Adds Backstage `catalog-info.yaml` for service discovery and catalog registration.